### PR TITLE
[WIP]Copds 961 add cads common

### DIFF
--- a/.github/workflows/build-broker.yml
+++ b/.github/workflows/build-broker.yml
@@ -58,7 +58,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ecmwf-projects/cads-deployment
-        ref: COPDS-961-add-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: .
 
@@ -73,7 +72,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ecmwf-projects/cads-common
-        ref: COPDS-961-create-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-common
 

--- a/.github/workflows/build-broker.yml
+++ b/.github/workflows/build-broker.yml
@@ -58,6 +58,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ecmwf-projects/cads-deployment
+        ref: COPDS-961-add-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: .
 
@@ -67,6 +68,14 @@ jobs:
         repository: ecmwf-projects/cacholote
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cacholote
+
+    - name: Clone cads-common repo
+      uses: actions/checkout@v2
+      with:
+        repository: ecmwf-projects/cads-common
+        ref: COPDS-961-create-cads-common
+        token: ${{ secrets.CADS_PAT }}
+        path: ./docker/cads-common
 
     - name: Checkout cads-broker repo
       uses: actions/checkout@v3

--- a/.github/workflows/build-cache-cleaner.yml
+++ b/.github/workflows/build-cache-cleaner.yml
@@ -58,6 +58,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ecmwf-projects/cads-deployment
+        ref: COPDS-961-add-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: .
 
@@ -74,6 +75,14 @@ jobs:
         repository: ecmwf-projects/cads-worker
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-worker
+
+    - name: Clone cads-common repo
+      uses: actions/checkout@v2
+      with:
+        repository: ecmwf-projects/cads-common
+        ref: COPDS-961-create-cads-common
+        token: ${{ secrets.CADS_PAT }}
+        path: ./docker/cads-common
 
     - name: Build and push
       uses: docker/build-push-action@v3

--- a/.github/workflows/build-cache-cleaner.yml
+++ b/.github/workflows/build-cache-cleaner.yml
@@ -58,7 +58,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ecmwf-projects/cads-deployment
-        ref: COPDS-961-add-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: .
 
@@ -80,7 +79,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ecmwf-projects/cads-common
-        ref: COPDS-961-create-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-common
 

--- a/.github/workflows/build-catalogue-api.yml
+++ b/.github/workflows/build-catalogue-api.yml
@@ -97,7 +97,7 @@ jobs:
       with:
         repository: ecmwf-projects/cads-common
         token: ${{ secrets.CADS_PAT }}
-        path: ./docker/cads-licences
+        path: ./docker/cads-common
 
     - name: Checkout cads-catalogue-api-service repo
       uses: actions/checkout@v3

--- a/.github/workflows/build-catalogue-api.yml
+++ b/.github/workflows/build-catalogue-api.yml
@@ -91,6 +91,13 @@ jobs:
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-licences
 
+    - name: Clone cads-common repo
+      uses: actions/checkout@v2
+      with:
+        repository: ecmwf-projects/cads-common
+        token: ${{ secrets.CADS_PAT }}
+        path: ./docker/cads-licences
+
     - name: Checkout cads-catalogue-api-service repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/build-catalogue-api.yml
+++ b/.github/workflows/build-catalogue-api.yml
@@ -57,7 +57,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ecmwf-projects/cads-deployment
-        ref: COPDS-961-add-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: .
 
@@ -96,7 +95,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ecmwf-projects/cads-common
-        ref: COPDS-961-create-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-common
 

--- a/.github/workflows/build-catalogue-api.yml
+++ b/.github/workflows/build-catalogue-api.yml
@@ -96,6 +96,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ecmwf-projects/cads-common
+        ref: COPDS-961-create-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-common
 

--- a/.github/workflows/build-catalogue-api.yml
+++ b/.github/workflows/build-catalogue-api.yml
@@ -57,6 +57,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ecmwf-projects/cads-deployment
+        ref: COPDS-961-add-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: .
 

--- a/.github/workflows/build-profiles-api.yml
+++ b/.github/workflows/build-profiles-api.yml
@@ -58,6 +58,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ecmwf-projects/cads-deployment
+        ref: COPDS-961-add-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: .
 

--- a/.github/workflows/build-profiles-api.yml
+++ b/.github/workflows/build-profiles-api.yml
@@ -74,7 +74,7 @@ jobs:
       with:
         repository: ecmwf-projects/cads-common
         token: ${{ secrets.CADS_PAT }}
-        path: ./docker/cads-licences
+        path: ./docker/cads-common
 
     - name: Checkout cads-extended-profiles repo
       uses: actions/checkout@v3

--- a/.github/workflows/build-profiles-api.yml
+++ b/.github/workflows/build-profiles-api.yml
@@ -58,7 +58,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ecmwf-projects/cads-deployment
-        ref: COPDS-961-add-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: .
 
@@ -73,7 +72,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ecmwf-projects/cads-common
-        ref: COPDS-961-create-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-common
 

--- a/.github/workflows/build-profiles-api.yml
+++ b/.github/workflows/build-profiles-api.yml
@@ -73,6 +73,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ecmwf-projects/cads-common
+        ref: COPDS-961-create-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-common
 

--- a/.github/workflows/build-profiles-api.yml
+++ b/.github/workflows/build-profiles-api.yml
@@ -68,6 +68,13 @@ jobs:
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-licences
 
+    - name: Clone cads-common repo
+      uses: actions/checkout@v2
+      with:
+        repository: ecmwf-projects/cads-common
+        token: ${{ secrets.CADS_PAT }}
+        path: ./docker/cads-licences
+
     - name: Checkout cads-extended-profiles repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/build-retrieve-api.yml
+++ b/.github/workflows/build-retrieve-api.yml
@@ -74,6 +74,13 @@ jobs:
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-catalogue
 
+    - name: Clone cads-common repo
+      uses: actions/checkout@v2
+      with:
+        repository: ecmwf-projects/cads-common
+        token: ${{ secrets.CADS_PAT }}
+        path: ./docker/cads-licences
+
     - name: Checkout ogc-api-processes-fastapi repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/build-retrieve-api.yml
+++ b/.github/workflows/build-retrieve-api.yml
@@ -80,7 +80,7 @@ jobs:
       with:
         repository: ecmwf-projects/cads-common
         token: ${{ secrets.CADS_PAT }}
-        path: ./docker/cads-licences
+        path: ./docker/cads-common
 
     - name: Checkout ogc-api-processes-fastapi repo
       uses: actions/checkout@v3

--- a/.github/workflows/build-retrieve-api.yml
+++ b/.github/workflows/build-retrieve-api.yml
@@ -57,7 +57,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ecmwf-projects/cads-deployment
-        ref: COPDS-961-add-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: .
 
@@ -79,7 +78,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ecmwf-projects/cads-common
-        ref: COPDS-961-create-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-common
 

--- a/.github/workflows/build-retrieve-api.yml
+++ b/.github/workflows/build-retrieve-api.yml
@@ -57,6 +57,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ecmwf-projects/cads-deployment
+        ref: COPDS-961-add-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: .
 

--- a/.github/workflows/build-retrieve-api.yml
+++ b/.github/workflows/build-retrieve-api.yml
@@ -79,6 +79,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ecmwf-projects/cads-common
+        ref: COPDS-961-create-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-common
 

--- a/.github/workflows/build-worker-mars.yml
+++ b/.github/workflows/build-worker-mars.yml
@@ -69,7 +69,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ecmwf-projects/cads-common
-        ref: COPDS-961-create-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-common
 

--- a/.github/workflows/build-worker-mars.yml
+++ b/.github/workflows/build-worker-mars.yml
@@ -65,6 +65,14 @@ jobs:
         token: ${{ secrets.CADS_PAT }}
         path: .
 
+    - name: Clone cads-common repo
+      uses: actions/checkout@v2
+      with:
+        repository: ecmwf-projects/cads-common
+        ref: COPDS-961-create-cads-common
+        token: ${{ secrets.CADS_PAT }}
+        path: ./docker/cads-common
+
     - name: Setup bitbucket netrc
       run: |
         echo "${{ secrets.BITBUCKET_NETRC }}" > docker/netrc

--- a/.github/workflows/build-worker.yml
+++ b/.github/workflows/build-worker.yml
@@ -76,7 +76,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: ecmwf-projects/cads-common
-        ref: COPDS-961-create-cads-common
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cads-common
 

--- a/.github/workflows/build-worker.yml
+++ b/.github/workflows/build-worker.yml
@@ -72,6 +72,14 @@ jobs:
         token: ${{ secrets.CADS_PAT }}
         path: ./docker/cacholote
 
+    - name: Clone cads-common repo
+      uses: actions/checkout@v2
+      with:
+        repository: ecmwf-projects/cads-common
+        ref: COPDS-961-create-cads-common
+        token: ${{ secrets.CADS_PAT }}
+        path: ./docker/cads-common
+
     - name: Checkout cads-adaptors repo
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Do not merge before removing `ref` line for `cads-deployment` and `cads-common` checkouts on:

- build-catalogue-api.yml
- build-profiles-api.ym
- build-retrieve-api.yml
- build-cache-cleaner.yml
- build-broker.yml
- build-worker.yml (only cads-common ref)
- build-worker-mars.yml (only cads-common ref)

Do NOT merge before this:

- https://github.com/ecmwf-projects/cads-common/pull/1