### PR TITLE
add dependabot to bump actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly


### PR DESCRIPTION
A few workflows such as [this one](https://github.com/ecmwf-projects/cads-build-farm/blob/9a19fa9621bd53b52c28198c63eaae50d374f683/.github/workflows/build-worker.yml#L76) use out-of-date actions (which trigger deprecation warnings).

Dependabot will check weekly if there are new actions, and will open a PR if new actions are found.